### PR TITLE
リラックス傾向に使用する心拍間隔の単位を s から ms に変更・UIの一部修正

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -70,8 +70,8 @@ function registerHandlers() {
 function loadSettings() {
   const defaultSettings = {
     retentionPeriod: 600,
-    thresholdHigh: 1.0,
-    thresholdLow: 0.8,
+    thresholdHigh: 1000,
+    thresholdLow: 800,
     sendHttp: false,
     sendUrl: "",
   };
@@ -119,7 +119,7 @@ function onReading() {
 
 function appendSample(heartRate) {
   const time = new Date().getTime();
-  const duration = 60 / heartRate;
+  const duration = 60 * 1000 / heartRate;
   const sample = [time, duration];
 
   state.samples.push(sample);
@@ -282,24 +282,27 @@ function onClickImage() {
 function displaySettings() {
   const { settings } = state;
 
-  el.thresholdHigh.text = `高しきい値：${settings.thresholdHigh.toFixed(3)}`;
-  el.thresholdLow.text = `低しきい値：${settings.thresholdLow.toFixed(3)}`;
-  el.retentionPeriod.text = `保持期間：${settings.retentionPeriod}`;
-  el.sendHttp.text = `HTTP送信：${settings.sendHttp ? "ON" : "OFF"}`;
+  const highDigits = settings.thresholdHigh < 1000 ? 1 : 0;
+  const lowDigits = settings.thresholdLow < 1000 ? 1 : 0;
+  el.thresholdHigh.text = `高しきい値:${settings.thresholdHigh.toFixed(highDigits)}`;
+  el.thresholdLow.text = `低しきい値:${settings.thresholdLow.toFixed(lowDigits)}`;
+  el.retentionPeriod.text = `保持期間:${settings.retentionPeriod}秒`;
+  el.sendHttp.text = `HTTP送信:${settings.sendHttp ? "ON" : "OFF"}`;
 }
 
 function displayRelax() {
-  el.currentRelax.text = `リラックス傾向：${state.currentRelax.toFixed(3)}`;
+  const digits = state.currentRelax < 1000 ? 1 : 0;
+  el.currentRelax.text = `[${state.samples.length}] ${state.currentRelax.toFixed(digits)}`;
 }
 
 function displayPreventDetection() {
-  el.preventDetection.text = `検出抑制：${
+  el.preventDetection.text = `検出抑制:${
     state.preventDetection ? "ON" : "OFF"
   }`;
 }
 
 function displayDetectionCount() {
-  el.detectionCount.text = `検出回数：${state.detectionCount}`;
+  el.detectionCount.text = `検出回数:${state.detectionCount}回`;
 }
 
 function displayTileList() {

--- a/companion/index.js
+++ b/companion/index.js
@@ -128,7 +128,7 @@ function loadRetentionPeriod() {
 
 function loadThresholdHigh() {
   const key = "thresholdHigh";
-  const defaultValue = 1.0;
+  const defaultValue = 1000;
   const type = "float";
 
   return loadNumber(key, defaultValue, type);
@@ -136,7 +136,7 @@ function loadThresholdHigh() {
 
 function loadThresholdLow() {
   const key = "thresholdLow";
-  const defaultValue = 0.8;
+  const defaultValue = 800;
   const type = "float";
 
   return loadNumber(key, defaultValue, type);

--- a/resources/index.view
+++ b/resources/index.view
@@ -1,25 +1,26 @@
 <svg>
   <use id="myList" href="#tile-list" class="horizontal-pad hidden" pointer-events="visible">
     <use href="#my-item" id="currentRelax">
-      <set href="#text" attributeName="text-buffer" to="リラックス傾向：X.XXX" />
+      <!-- [心拍サンプル数] リラックス傾向 -->
+      <set href="#text" attributeName="text-buffer" to="[XXX] XXX.X" />
     </use>
     <use href="#my-item" id="thresholdHigh">
-      <set href="#text" attributeName="text-buffer" to="高しきい値：X.XXX" />
+      <set href="#text" attributeName="text-buffer" to="高しきい値:XXX.X" />
     </use>
     <use href="#my-item" id="thresholdLow">
-      <set href="#text" attributeName="text-buffer" to="低しきい値：X.XXX" />
+      <set href="#text" attributeName="text-buffer" to="低しきい値:XXX.X" />
     </use>
     <use href="#my-item" id="retentionPeriod">
-      <set href="#text" attributeName="text-buffer" to="保持期間：XXXX秒" />
+      <set href="#text" attributeName="text-buffer" to="保持期間:XXX秒" />
     </use>
     <use href="#my-item" id="sendHttp">
-      <set href="#text" attributeName="text-buffer" to="HTTP送信：XXX" />
+      <set href="#text" attributeName="text-buffer" to="HTTP送信:XXX" />
     </use>
     <use href="#my-item" id="preventDetection">
-      <set href="#text" attributeName="text-buffer" to="検出抑制：XXX" />
+      <set href="#text" attributeName="text-buffer" to="検出抑制:XXX" />
     </use>
     <use href="#my-item" id="detectionCount">
-      <set href="#text" attributeName="text-buffer" to="検出回数：XXXX回" />
+      <set href="#text" attributeName="text-buffer" to="検出回数:XXX回" />
     </use>
   </use>
   <image x="68" y="34" width="200" height="200" href="normal_clear.png" id="image" class="" pointer-events="visible" />

--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -2,8 +2,8 @@ function HelloWorld(props) {
   return (
     <Page>
       <TextInput label="心拍数データの保持期間[秒]" placeholder="例：600" settingsKey="retentionPeriod" type="number"/>
-      <TextInput label="高リラックス状態の閾値" placeholder="例：1.2" settingsKey="thresholdHigh" type="number"/>
-      <TextInput label="低リラックス状態の閾値" placeholder="例：0.8" settingsKey="thresholdLow" type="number"/>
+      <TextInput label="高リラックス状態の閾値" placeholder="例：1000" settingsKey="thresholdHigh" type="number"/>
+      <TextInput label="低リラックス状態の閾値" placeholder="例：800" settingsKey="thresholdLow" type="number"/>
       <Toggle settingsKey="sendHttp" label="低リラックス検出時のHTTPリクエスト送信"/>
       <TextInput label="HTTPリクエストのURL" placeholder="例：https://example.com/api" settingsKey="sendUrl" type="url" disabled={!(props.settings.sendHttp === 'true')}/>
     </Page>


### PR DESCRIPTION
## Pull Request の詳細

closes #1

リラックス傾向の算出に使用する心拍間隔の単位を，秒からミリ秒に変更した．

また，これに合わせて一部UIの変更を行った．

## 実装によるユーザーへの影響・変更点

- リラックス傾向の表示値が実装前の1,000倍になる．
  - 以前からアプリを使っている場合は，しきい値の再設定が必要．
- 小数点の処理を変更．1000未満であれば小数第二位，そうでなければ小数第一位を四捨五入．
- 一番上の行の表示を `[現在の心拍サンプル数] 現在のリラックス傾向` に変更．

## 実装による開発者への影響・変更点

特になし

## 備考

### 小数点 (ピリオド) を含む文字列が正しく表示されない

<img width="474" alt="スクリーンショット 2024-11-20 13 26 34" src="https://github.com/user-attachments/assets/548f34ac-76cf-43af-b143-52aac9d86fff">

```
App: Error 84 Not enough space, string truncated to '[21] 929.'
```

文字列にピリオドが含まれていると「十分なスペースがない」という理由で，ピリオドよりも右側が表示されない不具合がある．当初は小数を表示する全ての場所でこれが起きていたが，使用するコロンを全角から半角に変更したところ，症状が発生するのは一番上のリラックス傾向のみとなった．

上記の不具合が残っているが，とりあえずはこのままメインブランチにマージすることにする．

「十分なスペースがない」という理由にもかかわらず，それよりも横幅を占有する他の文字列が正しく表示されているので，Fitbit SDKのバグの可能性もある．
