### PR TITLE
低リラックス検出時の通知を強化 (バイブレーション・画面が消灯していたら点灯)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,8 @@ import { me as appbit } from "appbit";
 import * as document from "document";
 import * as fs from "fs";
 import { HeartRateSensor } from "heart-rate";
+import { display } from "display";
+import { vibration } from "haptics";
 import * as messaging from "messaging";
 
 appbit.appTimeoutEnabled = false;
@@ -9,6 +11,7 @@ appbit.appTimeoutEnabled = false;
 const SETTINGS_FILE = "settings.json";
 const RESEND_INTERVAL = 5000;
 //const MIN_SAMPLES = 2;
+const VIBRATION_TIME = 1000;
 
 const imageRelaxMissingSamples = "blank.png";
 const imageRelaxHigh = "high_clear.png";
@@ -182,6 +185,9 @@ function detectLowRelax() {
       // 検出回数カウントを 1 増やします。
       state.detectionCount += 1;
 
+      // バイブレーションと画面点灯で知らせます。
+      notify();
+
       // HTTP リクエストを送信する設定になっているかをチェックしています。
       if (state.settings.sendHttp) {
         /** 送信される HTTP リクエストボディの内容です。 */
@@ -219,6 +225,14 @@ function disablePreventDetection() {
   if (state.currentRelax > state.settings.thresholdHigh) {
     state.preventDetection = false;
   }
+}
+
+function notify() {
+  if (vibration.start("nudge")) {
+    setTimeout(() => vibration.stop(), VIBRATION_TIME);
+  }
+
+  display.on = true;
 }
 
 function sendRequest(request) {


### PR DESCRIPTION
## Pull Request の詳細

closes #5

低リラックス状態を検出した時に，バイブレーションおよび画面点灯によって検出を知らせるようにした．

バイブレーションは，様々なパターンの中から短く1回振動する `nudge` というパターンを選定した．

### 参考にしたページ

- https://dev.fitbit.com/build/reference/device-api/haptics/
- https://dev.fitbit.com/build/reference/device-api/display/

## 実装によるユーザーへの影響・変更点

特になし

## 実装による開発者への影響・変更点

特になし