### PR TITLE
主観（手動）スイッチ機能

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -199,17 +199,8 @@ function detectLowRelax() {
 
       // HTTP リクエストを送信する設定になっているかをチェックしています。
       if (state.settings.sendHttp) {
-        /** 送信される HTTP リクエストボディの内容です。 */
-        const request = {
-          /** 送信日時です。 */
-          date: new Date().toISOString(),
-          /** 現在のリラックス傾向です。 */
-          relax: state.currentRelax,
-          /** 低リラックス状態のしきい値です。 */
-          threshold: state.settings.thresholdLow,
-          /** HTTP リクエストの再送信が行われたかを示すフラグです。 */
-          retry: false,
-        };
+        /** 送信される HTTP リクエストボディの内容を生成します。 */
+        const request = createRequest(false);
 
         /** HTTP リクエストの送信が成功したかどうかです。 */
         const sent = sendRequest(request);
@@ -242,6 +233,27 @@ function notify() {
   }
 
   display.on = true;
+}
+
+function createRequest(subjective) {
+  /** HTTPリクエストボディの生成 */
+  return {
+    /** 送信日時 */
+    date: new Date().toISOString(),
+    /** 現在のリラックス傾向 */
+    relax: state.currentRelax,
+    /** 心拍サンプルの所持時間 */
+    retentionPeriod: state.settings.retentionPeriod,
+    /** 高リラックス状態のしきい値 */
+    thresholdHigh: state.settings.thresholdHigh,
+    /** 低リラックス状態のしきい値 */
+    //threshold: state.settings.thresholdLow,
+    thresholdLow: state.settings.thresholdLow,
+    /** 主観スイッチであることを示すフラグ */
+    subjective,
+    /** HTTP リクエストの再送信が行われたかを示すフラグ */
+    retry: false,
+  };
 }
 
 function sendRequest(request) {

--- a/app/index.js
+++ b/app/index.js
@@ -18,9 +18,12 @@ const imageRelaxHigh = "high_clear.png";
 const imageRelaxNormal = "normal_clear.png";
 const imageRelaxLow = "low_clear.png";
 
-const textRelaxHigh = "リラックス傾向：高い";
-const textRelaxNormal = "リラックス傾向：通常";
-const textRelaxLow = "リラックス傾向：低い";
+const textRelaxHigh = "リラックス：高";
+const textRelaxNormal = "リラックス：通常";
+const textRelaxLow = "リラックス：低";
+
+const subjectiveSwitchClasses = "text-button primary application-fill";
+const showDetailsClasses = "text-button secondary application-fill";
 
 const el = {
   currentRelax: document.getElementById("currentRelax"),
@@ -33,6 +36,8 @@ const el = {
   tileList: document.getElementById("myList"),
   image: document.getElementById("image"),
   label: document.getElementById("label"),
+  subjectiveSwitch: document.getElementById("subjectiveSwitch"),
+  showDetails: document.getElementById("showDetails"),
 };
 
 const state = {
@@ -44,6 +49,7 @@ const state = {
   preventDetection: false,
   detectionCount: 0,
   showImage: true,
+  allowSubjectiveSwitch: false, // 主観スイッチの作動を許可
 };
 
 setup();
@@ -68,7 +74,7 @@ function registerHandlers() {
   setInterval(onTimeout, RESEND_INTERVAL);
 
   el.tileList.addEventListener("click", onClickTileList)
-  el.image.addEventListener("click", onClickImage)
+  el.showDetails.addEventListener("click", onClickShowDetails);
 }
 
 function loadSettings() {
@@ -115,9 +121,12 @@ function onReading() {
   removeSamples();
 
   if (state.samples.length == state.settings.retentionPeriod) {
+    state.allowSubjectiveSwitch = true;
     calculateRelax();
     detectLowRelax();
     disablePreventDetection();
+  } else {
+    state.allowSubjectiveSwitch = false;
   }
 
   displayRelax();
@@ -283,7 +292,7 @@ function onClickTileList() {
   displayImage();
 }
 
-function onClickImage() {
+function onClickShowDetails() {
   state.showImage = false;
   displayTileList();
   displayImage();
@@ -329,15 +338,24 @@ function displayTileList() {
 
 function displayImage() {
   if (state.showImage) {
+    const hidden = state.allowSubjectiveSwitch ? "" : " hidden";
+    
     el.image.class = "";
     el.label.class ="";
+    el.subjectiveSwitch.class = subjectiveSwitchClasses + hidden;
+    el.showDetails.class = showDetailsClasses;
   } else {
     el.image.class = "hidden";
     el.label.class = "hidden";
+    el.subjectiveSwitch.class = subjectiveSwitchClasses + " hidden";
+    el.showDetails.class = showDetailsClasses + " hidden";
   }
 }
 
 function displayRelaxImage() {
+  const hidden = state.showImage && state.allowSubjectiveSwitch ? "" : " hidden";
+  el.subjectiveSwitch.class = subjectiveSwitchClasses + hidden;
+
   if (state.samples.length < state.settings.retentionPeriod) {
     el.image.href = imageRelaxMissingSamples;
     el.label.text = `蓄積中... ${state.samples.length} / ${state.settings.retentionPeriod}`;

--- a/resources/index.view
+++ b/resources/index.view
@@ -18,8 +18,8 @@
     <use href="#my-item" id="preventDetection">
       <set href="#text" attributeName="text-buffer" to="検出抑制:XXX" />
     </use>
-    <use href="#my-item" id="detectionCount">
-      <set href="#text" attributeName="text-buffer" to="検出回数:XXX回" />
+    <use href="#my-item" id="count">
+      <set href="#text" attributeName="text-buffer" to="検出:XXX回 主観:XXX回" />
     </use>
   </use>
   <image x="10" y="10" width="96" height="96" href="blank.png" id="image" class="" pointer-events="visible" />

--- a/resources/index.view
+++ b/resources/index.view
@@ -22,6 +22,12 @@
       <set href="#text" attributeName="text-buffer" to="検出回数:XXX回" />
     </use>
   </use>
-  <image x="68" y="34" width="200" height="200" href="blank.png" id="image" class="" pointer-events="visible" />
-  <text x="50%" y="272" font-family="System-Regular" fill="white" font-size="24" font-weight="bold" text-anchor="middle" id="label">蓄積中... 0 / XXX</text>
+  <image x="10" y="10" width="96" height="96" href="blank.png" id="image" class="" pointer-events="visible" />
+  <text x="60%" y="70" font-family="System-Regular" fill="white" font-size="24" font-weight="bold" text-anchor="middle" id="label">蓄積中... 0 / XXX</text>
+  <use href="#text-button" id="subjectiveSwitch" class="text-button primary application-fill hidden">
+    <set href="#text" attributeName="text-buffer" to="ストレスを感じたら押す" />
+  </use>
+  <use href="#text-button" id="showDetails" class="text-button secondary application-fill">
+    <set href="#text" attributeName="text-buffer" to="詳細表示へ" />
+  </use>
 </svg>

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -24,3 +24,16 @@
 #label {
   text-length: 100;
 }
+
+/* 以下，ボタン用のCSS */
+.application-fill {
+  fill: fb-cyan;
+}
+
+.foreground-fill {
+  fill: fb-white;
+}
+
+.background-fill {
+  fill: fb-black;
+}

--- a/resources/widget.defs
+++ b/resources/widget.defs
@@ -6,6 +6,7 @@
     <link rel="import" href="/mnt/sysassets/widgets/baseview_widget.defs" />
     <link rel="import" href="/mnt/sysassets/widgets/scrollbar.defs" />
     <link rel="import" href="/mnt/sysassets/widgets/tile_list_widget.defs" />
+    <link rel="import" href="/mnt/sysassets/widgets/text_button.defs" />
 
     <symbol id="my-item" href="#tile-list-item" class="list-item">
       <text id="text" />


### PR DESCRIPTION
## Pull Request の詳細

closes #8 

主観スイッチ機能を実装した．

- アイコン表示画面を変更し「主観スイッチを発動する」ボタンと「詳細表示に切り替える」ボタンを追加．
- 主観スイッチ実装に合わせてHTTPリクエストの中身を変更（項目を追加）．
- 主観スイッチは上記のボタンを押して発動させる．ただし，押した後 `RESEND_INTERVAL` と同じ秒数の間 (実際には+1～2秒) は無効化．
- 主観と客観それぞれで発生回数をカウントできるようにした．

### UIの変更 (ボタンの追加)

![スクリーンショット 2024-11-24 163229](https://github.com/user-attachments/assets/befdfccc-5208-47bb-be24-a312eb49a215)

「主観スイッチ」のボタンは，心拍サンプルの蓄積中（起動直後）は表示されない．また，上述のように押した直後も無効化され一定時間非表示となる．

### HTTPリクエストボディの内容変更

※**太字**は追加した項目

- `date` 送信日時
- `relax` 現在のリラックス傾向
- `retensionPeriod` **心拍サンプルの所持時間 (秒)**
- `thresholdHigh` **高リラックス状態のしきい値**
- `threshold` => `thresholdLow` 低リラックス状態のしきい値
- `subjective` **主観スイッチかどうかのフラグ**
- `retry` HTTPリクエストの再送信が行われたかのフラグ

## 実装によるユーザーへの影響・変更点

- HTTPリクエストボディの内容変更

## 実装による開発者への影響・変更点

特になし