### PR TITLE
リクエスト送信時のステータスコードが正常に取得できるようにする

### DIFF
--- a/companion/index.js
+++ b/companion/index.js
@@ -79,7 +79,7 @@ function onTimeout() {
 
 async function sendRequest(url, request) {
   try {
-    const response = fetch(url, {
+    const response = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Pull Request の詳細

closes #10 

リクエスト送信時のレスポンスのステータスコードが正しく取得できていなかった．
`fetch` 関数の前の await が抜けていたのでコードを修正する．

## 実装によるユーザーへの影響・変更点

特になし

## 実装による開発者への影響・変更点

特になし